### PR TITLE
use new startup function name

### DIFF
--- a/TwoEars.xml
+++ b/TwoEars.xml
@@ -11,5 +11,5 @@ startTwoEars('Config.xml'). -->
     <TwoEarsPart sub="API_MO" startup="SOFAstart">sofa</TwoEarsPart>
     <TwoEarsPart startup="startAuditoryFrontEnd">auditory-front-end</TwoEarsPart>
     <TwoEarsPart startup="startBlackboardSystem">blackboard-system</TwoEarsPart>
-    <TwoEarsPart startup="startIdentificationTraining">identification-training</TwoEarsPart>
+    <TwoEarsPart startup="startAMLTTP">identification-training</TwoEarsPart>
 </requirements>


### PR DESCRIPTION
This updates the startup value in TwoEars.xml config file.

We should probably start talking about updating things to reflect the new name of the repo (Auditory-Machine-Learning-Training-and-Testing-Pipeline instead of identification-training-pipeline)

@ivo--t 
